### PR TITLE
Add support for time limited credentials auth

### DIFF
--- a/jostedal/stun/agent.py
+++ b/jostedal/stun/agent.py
@@ -216,7 +216,7 @@ class Message(bytearray):
                 self.msg_class,
                 len(self) - self._struct.size,
                 self.magic_cookie,
-                self.transaction_id.encode("hex"),
+                self.transaction_id.hex(),
                 self._attributes,
             )
         )

--- a/jostedal/stun/agent.py
+++ b/jostedal/stun/agent.py
@@ -44,7 +44,7 @@ class StunUdpProtocol(DatagramProtocol):
         msg_type = datagram[0] >> 6
         if msg_type == stun.MSG_STUN:
             try:
-                msg = Message.decode(datagram)
+                msg = Message.from_buffer(datagram)
             except Exception:
                 logger.exception("Failed to decode STUN from %s:%d:", *addr)
                 logger.debug(datagram.encode("hex"))
@@ -101,7 +101,7 @@ class Message(bytearray):
         self._attributes = []
 
     @classmethod
-    def encode(
+    def from_str(
         cls,
         msg_method,
         msg_class,
@@ -117,7 +117,7 @@ class Message(bytearray):
         return message
 
     def add_attr(self, attr_cls, *args, **kwargs):
-        attr = attr_cls.encode(self, *args, **kwargs)
+        attr = attr_cls.from_str(self, *args, **kwargs)
         self.extend(Attribute.struct.pack(attr.type, len(attr)))
         self.extend(attr)
         self.extend(self._padding(attr.padding))
@@ -132,7 +132,7 @@ class Message(bytearray):
                 return attr
 
     @classmethod
-    def decode(cls, data):
+    def from_buffer(cls, data):
         """
         :see: http://tools.ietf.org/html/rfc5389#section-7.3.1
         """
@@ -157,7 +157,7 @@ class Message(bytearray):
         while offset < cls._struct.size + msg_length:
             attr_type, attr_length = Attribute.struct.unpack_from(data, offset)
             offset += Attribute.struct.size
-            attr = cls.get_attr_cls(attr_type).decode(data, offset, attr_length)
+            attr = cls.get_attr_cls(attr_type).from_buffer(data, offset, attr_length)
             msg._attributes.append(attr)
             offset += len(attr)
             offset += attr.padding
@@ -203,7 +203,7 @@ class Message(bytearray):
         return attr_cls.__name__ if attr_cls else "{:#06x}".format(attr_type)
 
     def create_response(self, msg_class):
-        return self.encode(
+        return self.from_str(
             self.msg_method, msg_class, self.magic_cookie, self.transaction_id
         )
 
@@ -249,11 +249,11 @@ class Attribute(bytes):
         return bytes.__new__(cls, data)
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         return cls(memoryview(data)[offset : offset + length])
 
     @classmethod
-    def encode(cls, msg, data):
+    def from_str(cls, msg, data):
         return cls(data)
 
     @property
@@ -303,7 +303,7 @@ class Address(Attribute):
         self.address = address
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         family, port = cls.struct.unpack_from(data, offset)
         packed_ip = memoryview(data)[offset + cls.struct.size : offset + length]
         if cls._xored:
@@ -317,7 +317,7 @@ class Address(Attribute):
         return cls(value, family, port, address)
 
     @classmethod
-    def encode(cls, msg, family, port, address):
+    def from_str(cls, msg, family, port, address):
         xport = port
         packed_ip = socket.inet_pton(Address.ftoaf(family), address)
         if cls._xored:

--- a/jostedal/stun/client.py
+++ b/jostedal/stun/client.py
@@ -24,8 +24,7 @@ class StunUdpClient(StunUdpProtocol):
         return self.request(request, addr)
 
     def request(self, request, addr):
-        """Send a STUN request
-        """
+        """Send a STUN request"""
         self.credential_mechanism.update(request)
         request.add_attr(attributes.Fingerprint)
         transaction = StunTransaction(request, addr)

--- a/jostedal/stun/client.py
+++ b/jostedal/stun/client.py
@@ -19,7 +19,7 @@ class StunUdpClient(StunUdpProtocol):
         """
         :see: http://tools.ietf.org/html/rfc5389#section-7.1
         """
-        request = Message.encode(stun.METHOD_BINDING, stun.CLASS_REQUEST)
+        request = Message.from_str(stun.METHOD_BINDING, stun.CLASS_REQUEST)
         request.add_attr(attributes.Software, self.software)
         return self.request(request, addr)
 

--- a/jostedal/stun/server.py
+++ b/jostedal/stun/server.py
@@ -24,7 +24,7 @@ class StunUdpServer(StunUdpProtocol):
         if msg.msg_class == stun.CLASS_REQUEST:
             unknown_attributes = msg.unknown_comp_required_attrs()
             if unknown_attributes:
-                response = Message.encode(
+                response = Message.from_str(
                     stun.METHOD_BINDING,
                     stun.CLASS_RESPONSE_ERROR,
                     transaction_id=msg.transaction_id,
@@ -32,7 +32,7 @@ class StunUdpServer(StunUdpProtocol):
                 response.add_attr(attributes.ErrorCode, *stun.ERR_UNKNOWN_ATTRIBUTE)
                 response.add_attr(attributes.UnknownAttributes, unknown_attributes)
             else:
-                response = Message.encode(
+                response = Message.from_str(
                     stun.METHOD_BINDING,
                     stun.CLASS_RESPONSE_SUCCESS,
                     transaction_id=msg.transaction_id,

--- a/jostedal/turn/attributes.py
+++ b/jostedal/turn/attributes.py
@@ -13,7 +13,7 @@ class ChannelNumber(Attribute):
         self.channel_number = channel_number
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         channel_number = struct.unpack_from(">H2x", data, offset)
         return cls(memoryview(data)[offset : offset + length], channel_number)
 
@@ -33,12 +33,12 @@ class Lifetime(Attribute):
         self.time_to_expiry = time_to_expiry
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         (lifetime,) = cls._struct.unpack_from(data, offset)
         return cls(memoryview(data)[offset : offset + length], lifetime)
 
     @classmethod
-    def encode(cls, msg, time_to_expiry):
+    def from_str(cls, msg, time_to_expiry):
         return cls(cls._struct.pack(time_to_expiry), time_to_expiry)
 
     def __repr__(self):
@@ -87,7 +87,7 @@ class EvenPort(Attribute):
     RESERVE = 0b10000000
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         return struct.unpack_from(">B", data, offset)[0] & 0b10000000
 
 
@@ -104,11 +104,11 @@ class RequestedTransport(Attribute):
         self.protocol = protocol
 
     @classmethod
-    def encode(cls, msg, protocol):
+    def from_str(cls, msg, protocol):
         return cls(cls._struct.pack(protocol), protocol)
 
     @classmethod
-    def decode(cls, data, offset, length):
+    def from_buffer(cls, data, offset, length):
         (protocol,) = cls._struct.unpack_from(data, offset)
         return cls(memoryview(data)[offset : offset + length], protocol)
 

--- a/jostedal/turn/client.py
+++ b/jostedal/turn/client.py
@@ -76,7 +76,7 @@ class TurnUdpClient(StunUdpClient):
         :param even_port: None | 0 | 1 (1==reserve next highest port number)
         :see: http://tools.ietf.org/html/rfc5766#section-6.1
         """
-        request = Message.encode(turn.METHOD_ALLOCATE, stun.CLASS_REQUEST)
+        request = Message.from_str(turn.METHOD_ALLOCATE, stun.CLASS_REQUEST)
         request.add_attr(attributes.RequestedTransport, transport)
         if time_to_expiry:
             request.add_attr(turn.ATTR_LIFETIME, time_to_expiry)
@@ -102,7 +102,7 @@ class TurnUdpClient(StunUdpClient):
         """
         :see: http://tools.ietf.org/html/rfc5766#section-6
         """
-        request = Message.encode(turn.METHOD_REFRESH, stun.CLASS_REQUEST)
+        request = Message.from_str(turn.METHOD_REFRESH, stun.CLASS_REQUEST)
         if time_to_expiry:
             request.add_attr(turn.ATTR_LIFETIME, time_to_expiry)
 

--- a/jostedal/turn/relay.py
+++ b/jostedal/turn/relay.py
@@ -58,7 +58,7 @@ class Relay(DatagramProtocol):
                 # TODO: send channel message to client
                 raise NotImplementedError("Send channel message")
             else:
-                msg = Message.encode(turn.METHOD_DATA, stun.CLASS_INDICATION)
+                msg = Message.from_str(turn.METHOD_DATA, stun.CLASS_INDICATION)
                 family = Address.aftof(self.transport.addressFamily)
                 msg.add_attr(attributes.XorPeerAddress, family, port, host)
                 msg.add_attr(attributes.Data, datagram)

--- a/jostedal/turn/server.py
+++ b/jostedal/turn/server.py
@@ -49,6 +49,8 @@ class TurnUdpServer(StunUdpServer):
             # TODO: handle allocate retransmission
             raise NotImplementedError("Allocation retransmission")
 
+        generated_username = msg.get_attr(stun.ATTR_USERNAME)
+        self.credential_mechanism.add_key_user(generated_username)
         # 1. require request to be authenticated
         message_integrity = msg.get_attr(stun.ATTR_MESSAGE_INTEGRITY)
         if not message_integrity:

--- a/jostedal/utils.py
+++ b/jostedal/utils.py
@@ -1,4 +1,9 @@
 import hashlib
+import base64
+
+from cryptography.hazmat.backends.openssl import backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.hmac import HMAC
 
 
 def saslprep(string):
@@ -10,3 +15,17 @@ def ha1(username, realm, password):
     return hashlib.md5(
         ":".join((username, realm, saslprep(password))).encode()
     ).digest()
+
+
+def secret_key(username, realm, password):
+    """
+    Generate passwords for Coturn REST api. See the "TURN REST API" section in
+    README.turnserver in the coturn source code for algorithm details.
+    """
+    # Using sha1 because it's required by the TURN server API
+    print(type(password))
+    hmac = HMAC(password.encode(), hashes.SHA1(), backend)  # nosec
+    hmac.update(username.encode())
+    password = base64.b64encode(hmac.finalize()).decode("utf-8")
+
+    return hashlib.md5(":".join((username, realm, password)).encode()).digest()

--- a/jostedal/utils.py
+++ b/jostedal/utils.py
@@ -23,7 +23,6 @@ def secret_key(username, realm, password):
     README.turnserver in the coturn source code for algorithm details.
     """
     # Using sha1 because it's required by the TURN server API
-    print(type(password))
     hmac = HMAC(password.encode(), hashes.SHA1(), backend)  # nosec
     hmac.update(username.encode())
     password = base64.b64encode(hmac.finalize()).decode("utf-8")

--- a/test/unit/test_stun.py
+++ b/test/unit/test_stun.py
@@ -1,4 +1,5 @@
 import unittest
+import codecs
 from jostedal import stun
 from jostedal.stun.agent import Message, Address, Unknown
 from jostedal.stun import attributes
@@ -7,7 +8,7 @@ from jostedal.utils import ha1
 
 class MessageTest(unittest.TestCase):
     def setUp(self):
-        msg_data = (
+        msg_data = codecs.decode((
             "011300602112a442fedcb2d51f23946d"
             "9cc9754e0009001000000401556e6175"
             "74686f72697365640015001036303332"
@@ -16,7 +17,7 @@ class MessageTest(unittest.TestCase):
             "4369747269782d312e382e372e302027"
             "426c61636b20446f77270004"
             "802800045a4c0c70"  # Fingerprint
-        ).decode("hex")
+        ), "hex")
         self.msg = Message.decode(msg_data)
 
     def test_decode(self):
@@ -41,9 +42,9 @@ class MessageTest(unittest.TestCase):
             stun.METHOD_BINDING, stun.CLASS_REQUEST, transaction_id="fixedtransid"
         )
         # Override padding generation to make the message data deterministic
-        msg._padding = "\x00".__mul__  # Pad with zero bytes
+        msg._padding = b"\x00".__mul__  # Pad with zero bytes
 
-        msg.add_attr(type("Foo", (Unknown,), {"type": 0x6666}), "data")
+        msg.add_attr(type("Foo", (Unknown,), {"type": 0x6666}), b"data")
         msg.add_attr(
             attributes.MappedAddress, Address.FAMILY_IPv4, 1337, "192.168.2.255"
         )
@@ -51,8 +52,8 @@ class MessageTest(unittest.TestCase):
         msg.add_attr(attributes.MessageIntegrity, ha1("username", "realm", "password"))
         msg.add_attr(attributes.ErrorCode, *stun.ERR_SERVER_ERROR)
         msg.add_attr(attributes.UnknownAttributes, [0x1337, 0xB00B, 0xBEEF])
-        msg.add_attr(attributes.Realm, "pexip.com")
-        msg.add_attr(attributes.Nonce, "36303332376331373134356137373838".decode("hex"))
+        msg.add_attr(attributes.Realm, b"pexip.com")
+        msg.add_attr(attributes.Nonce, codecs.decode("36303332376331373134356137373838", "hex"))
         msg.add_attr(
             attributes.XorMappedAddress, Address.FAMILY_IPv4, 1337, "192.168.2.255"
         )
@@ -62,7 +63,7 @@ class MessageTest(unittest.TestCase):
         )
         msg.add_attr(attributes.Fingerprint)
 
-        msg_data = (
+        msg_data = codecs.decode((
             "000100bc2112a4426669786564747261"
             "6e736964666600046461746100010008"
             "00010539c0a802ff000600076a6f686e"
@@ -76,9 +77,9 @@ class MessageTest(unittest.TestCase):
             "e89db4e89db62068c3ba6469c3a92027"
             "627574746572666c7927000080230008"
             "00011f48c0a8028080280004e43217b7"
-        ).decode("hex")
+        ), "hex")
 
-        self.assertEqual(str(msg), msg_data)
+        self.assertEqual(Message.decode(msg), msg_data)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_stun.py
+++ b/test/unit/test_stun.py
@@ -22,7 +22,7 @@ class MessageTest(unittest.TestCase):
     def test_decode(self):
         error_code = self.msg.get_attr(stun.ATTR_ERROR_CODE)
         self.assertEqual(error_code.code, 401)
-        self.assertEqual(error_code.reason, u"Unauthorised")
+        self.assertEqual(error_code.reason, "Unauthorised")
 
         nonce = self.msg.get_attr(stun.ATTR_NONCE)
         self.assertEqual(nonce, "60327c17145a7788")
@@ -56,7 +56,7 @@ class MessageTest(unittest.TestCase):
         msg.add_attr(
             attributes.XorMappedAddress, Address.FAMILY_IPv4, 1337, "192.168.2.255"
         )
-        msg.add_attr(attributes.Software, u"\u8774\u8776 h\xfadi\xe9 'butterfly'")
+        msg.add_attr(attributes.Software, "\u8774\u8776 h\xfadi\xe9 'butterfly'")
         msg.add_attr(
             attributes.AlternateServer, Address.FAMILY_IPv4, 8008, "192.168.2.128"
         )

--- a/test/unit/test_stun.py
+++ b/test/unit/test_stun.py
@@ -37,7 +37,7 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(fingerprint, "5a4c0c70".decode("hex"))
 
     def test_encode(self):
-        msg = Message.encode(
+        msg = Message.from_str(
             stun.METHOD_BINDING, stun.CLASS_REQUEST, transaction_id="fixedtransid"
         )
         # Override padding generation to make the message data deterministic


### PR DESCRIPTION
Add support for time limited credential authentication as according to https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00.

Also refactors the naming of decode/encode so it does not overwrite the `bytes` base implementation
